### PR TITLE
fix garbage data being sent over ws when exiting from spectator screen

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -235,12 +235,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             }, 12_000);
         }
 
-        public override void OnSuspending(ScreenTransitionEvent e)
-        {
-            broadcastServer.Remove(mpGameplayStateBroadcaster);
-            base.OnSuspending(e);
-        }
-
         protected override void Update()
         {
             base.Update();
@@ -339,7 +333,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         public override bool OnExiting(ScreenExitEvent e)
         {
             if (isExiting)
-                return base.OnExiting(e);
+            {
+                bool cancelExit = base.OnExiting(e);
+
+                if (!cancelExit)
+                    broadcastServer.Remove(mpGameplayStateBroadcaster);
+
+                return cancelExit;
+            }
 
             if (multiplayerClient.Room?.State == MultiplayerRoomState.Results)
                 (multiplayerClient as IMultiplayerClient).RoomStateChanged(MultiplayerRoomState.Open);


### PR DESCRIPTION
gameplay state broadcaster was not being disposed correctly when exiting multispectatorscreen

leftover broadcaster instances send messages when exiting from multispectatorscreen again later on, with stale data from previous map