### PR TITLE
add float parsing for mods parameter, add generic type guard

### DIFF
--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -214,11 +214,25 @@ namespace osu.Game.Online.Chat
                         bParamValueDouble.Value = Convert.ToDouble(parametersList[i]);
                         break;
 
+                    case BindableNumber<float> bParamValueFloat:
+                        bParamValueFloat.Value = Convert.ToSingle(parametersList[i]);
+                        break;
+
                     case BindableBool bParamValueBool:
                         bParamValueBool.Value = Convert.ToBoolean(parametersList[i]);
                         break;
 
                     case IBindable bindable:
+                        var bindableType = bindable.GetType();
+
+                        if (!bindableType.IsGenericType)
+                        {
+                            Logger.Log($@"{acronym}'s {paramAttr.Label} is not a generic type ({bindableType.Name}), expected generic type. Skipping.",
+                                LoggingTarget.Runtime,
+                                LogLevel.Important);
+                            break;
+                        }
+
                         var enumType = bindable.GetType().GetGenericArguments()[0];
 
                         if (enumType.IsEnum)


### PR DESCRIPTION
It was previously assumed that all mods with floating point type parameters use BindableDouble, but it isn't the case (Approach Different). This adds the missing handler for BindableFloat.

This also adds a generic type guard in the fallback path (`IBindable`) such that the game doesn't crash when encountering an unhandled type.