### PR TITLE
set playlist map regardless of client map download status

### DIFF
--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -311,13 +311,16 @@ namespace osu.Game.Online.Chat
                                 {
                                     APIBeatmap beatmapInfo = task.GetResultSafely();
 
-                                    if (beatmapInfo?.BeatmapSet == null) return;
+                                    if (beatmapInfo?.BeatmapSet == null)
+                                    {
+                                        botMessageQueue.Enqueue(new Tuple<string, Channel>($@"Couldn't retrieve metadata for map ID {numericParam}", Channel.Value));
+                                        return;
+                                    }
 
                                     addPlaylistItem(beatmapInfo);
 
                                     RemoveInternal(beatmapDownloadTracker, true);
                                     AddInternal(beatmapDownloadTracker = new BeatmapDownloadTracker(beatmapInfo.BeatmapSet));
-
                                     beatmapDownloadTracker.State.BindValueChanged(changeEvent =>
                                     {
                                         switch (changeEvent.NewValue)

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -313,6 +313,8 @@ namespace osu.Game.Online.Chat
 
                                     if (beatmapInfo?.BeatmapSet == null) return;
 
+                                    addPlaylistItem(beatmapInfo);
+
                                     RemoveInternal(beatmapDownloadTracker, true);
                                     AddInternal(beatmapDownloadTracker = new BeatmapDownloadTracker(beatmapInfo.BeatmapSet));
 
@@ -321,7 +323,7 @@ namespace osu.Game.Online.Chat
                                         switch (changeEvent.NewValue)
                                         {
                                             case DownloadState.LocallyAvailable:
-                                                addPlaylistItem(beatmapInfo);
+                                                beatmapDownloadTracker.State.UnbindAll();
                                                 return;
 
                                             case DownloadState.NotDownloaded:


### PR DESCRIPTION
at some point, !mp map relied on having the map's MD5 but that has been removed since. we're able to set the playlist item just by calling the beatmap lookup cache