### PR TITLE
add additional logging around chat message processing

### DIFF
--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Online.Chat
                 if (messageQueue.Count > 0)
                 {
                     (string text, var target) = messageQueue.Dequeue();
-                    channelManager?.PostMessage(text, target: target);
+                    sendMessageAndLog(text, target);
                     Scheduler.AddDelayed(processMessageQueue, 1250);
                     return;
                 }
@@ -172,7 +172,8 @@ namespace osu.Game.Online.Chat
                 if (botMessageQueue.Count > 0)
                 {
                     (string text, Channel target) = botMessageQueue.Dequeue();
-                    channelManager?.PostMessage($@"[TESTOpenBot]: {text}", target: target);
+                    string message = $@"[TESTOpenBot]: {text}";
+                    sendMessageAndLog(message, target);
                     Scheduler.AddDelayed(processMessageQueue, 1250);
                     return;
                 }
@@ -180,6 +181,19 @@ namespace osu.Game.Online.Chat
 
             // no message has been posted
             Scheduler.AddDelayed(processMessageQueue, 50);
+            return;
+
+            void sendMessageAndLog(string message, Channel target)
+            {
+                if (channelManager != null)
+                {
+                    Logger.Log($"Sent \"{message}\" to {target}");
+                    channelManager.PostMessage(message, target: target);
+                    return;
+                }
+
+                Logger.Log($"Couldn't send \"{message}\" to {target}: channelManager is null");
+            }
         }
 
         [CanBeNull]

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -281,7 +281,17 @@ namespace osu.Game.Online.Chat
         protected virtual StandAloneDrawableChannel CreateDrawableChannel(Channel channel) =>
             new StandAloneDrawableChannel(channel);
 
-        public void EnqueueBotMessage(string message) => botMessageQueue.Enqueue(new Tuple<string, Channel>(message, Channel.Value));
+        public void EnqueueBotMessage(string message)
+        {
+            Logger.Log($"Queued \"{message}\" as bot message");
+            botMessageQueue.Enqueue(new Tuple<string, Channel>(message, Channel.Value));
+        }
+
+        public void EnqueueUserMessage(string message)
+        {
+            Logger.Log($"Queued \"{message}\" as user message");
+            messageQueue.Enqueue(new Tuple<string, Channel>(message, Channel.Value));
+        }
 
         private void postMessage(TextBox sender, bool newText)
         {
@@ -294,7 +304,7 @@ namespace osu.Game.Online.Chat
                 channelManager?.PostCommand(text.Substring(1), Channel.Value);
             else
             {
-                messageQueue.Enqueue(new Tuple<string, Channel>(text, Channel.Value));
+                EnqueueUserMessage(text);
 
                 string[] parts = text.Split();
 
@@ -316,7 +326,7 @@ namespace osu.Game.Online.Chat
 
                                     if (beatmapInfo?.BeatmapSet == null)
                                     {
-                                        botMessageQueue.Enqueue(new Tuple<string, Channel>($@"Couldn't retrieve metadata for map ID {numericParam}", Channel.Value));
+                                        EnqueueBotMessage($@"Couldn't retrieve metadata for map ID {numericParam}");
                                         return;
                                     }
 
@@ -500,7 +510,7 @@ namespace osu.Game.Online.Chat
             chatTimerHandler.Abort();
 
             // move this into ChatTimerHandler?
-            botMessageQueue.Enqueue(new Tuple<string, Channel>(@"Countdown aborted", Channel.Value));
+            EnqueueBotMessage(@"Countdown aborted");
         }
 
         private void addPlaylistItem(APIBeatmap beatmapInfo, APIMod[] requiredMods = null, APIMod[] allowedMods = null)
@@ -577,7 +587,7 @@ namespace osu.Game.Online.Chat
 
                 var rnd = new Random();
                 long randomNumber = rnd.NextInt64(1, limit);
-                botMessageQueue.Enqueue(new Tuple<string, Channel>($@"{message.Sender} rolls {randomNumber}", Channel.Value));
+                EnqueueBotMessage($@"{message.Sender} rolls {randomNumber}");
             }
         }
 


### PR DESCRIPTION
https://discord.com/channels/1139016216032333884/1183668110734135346/1236713887118659667

timer mysteriously stopped working, despite the fact that logs show the timer was scheduled successfully
```
2024-05-05 16:19:12 [verbose]: Sent timer message, 90 seconds remaining on timer.
2024-05-05 16:19:12 [verbose]: Time until next timer message: 29899.775299999994ms
2024-05-05 16:19:42 [verbose]: Sent timer message, 60 seconds remaining on timer.
2024-05-05 16:19:42 [verbose]: Time until next timer message: 29899.603199999998ms
2024-05-05 16:20:06 [verbose]: Received beatmap updates 1 updates with last id 8293412
2024-05-05 16:20:11 [verbose]: Received beatmap updates 1 updates with last id 8293413
2024-05-05 16:20:12 [verbose]: Sent timer message, 30 seconds remaining on timer.
2024-05-05 16:20:12 [verbose]: Time until next timer message: 9872.1636ms
2024-05-05 16:20:22 [verbose]: Sent timer message, 20 seconds remaining on timer.
2024-05-05 16:20:22 [verbose]: Time until next timer message: 9899.6195ms
2024-05-05 16:20:24 [verbose]: Sent timer message, 90 seconds remaining on timer.
2024-05-05 16:20:24 [verbose]: Time until next timer message: 29899.375ms
2024-05-05 16:20:54 [verbose]: Sent timer message, 60 seconds remaining on timer.
2024-05-05 16:20:54 [verbose]: Time until next timer message: 29885.0899ms
2024-05-05 16:21:11 [verbose]: Received beatmap updates 2 updates with last id 8293415
2024-05-05 16:21:24 [verbose]: Sent timer message, 30 seconds remaining on timer.
2024-05-05 16:21:24 [verbose]: Time until next timer message: 9899.2422ms
```

this PR adds additional logging around the message sending process