### PR TITLE
add aborttimer on argumentless code path

### DIFF
--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -486,6 +486,11 @@ namespace osu.Game.Online.Chat
 
                             Client.AbortMatch().FireAndForget();
                             break;
+
+                        // ReSharper disable once StringLiteralTypo
+                        case @"aborttimer":
+                            abortTimer();
+                            break;
                     }
 
                     break;


### PR DESCRIPTION
`!mp aborttimer` used to require an argument (which is wrong). This PR allows using `!mp aborttimer` by itself