### PR TITLE
immediately show replay after importing

### DIFF
--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -180,7 +180,21 @@ namespace osu.Game.Overlays
             notification.Closed += () => notificationClosed(notification);
 
             if (notification is IHasCompletionTarget hasCompletionTarget)
-                hasCompletionTarget.CompletionTarget = Post;
+            {
+                if (hasCompletionTarget.CompletionTarget != null)
+                {
+                    var originalCompletionTarget = hasCompletionTarget.CompletionTarget;
+                    hasCompletionTarget.CompletionTarget = (notification1 =>
+                    {
+                        Scheduler.AddOnce(() => originalCompletionTarget?.Invoke(notification1));
+                        Post(notification1);
+                    });
+                }
+                else
+                {
+                    hasCompletionTarget.CompletionTarget = Post;
+                }
+            }
 
             playDebouncedSample(notification.PopInSampleName);
 


### PR DESCRIPTION
This is useful for mappool showcases, requiring one fewer click on the replay import notification.