### PR TITLE
add !mp start

### DIFF
--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -342,6 +342,7 @@ namespace osu.Game.Online.Chat
                                 break;
 
                             case @"start":
+                                chatTimerHandler?.SetTimer(TimeSpan.FromSeconds(numericParam), Time.Current, messagePrefix: @"Match starts in", onTimerComplete: startMatch);
                                 break;
                         }
                     }
@@ -493,21 +494,7 @@ namespace osu.Game.Online.Chat
 
                         // start immediately
                         case @"start":
-                            if (!Client.IsHost)
-                            {
-                                Logger.Log(@"Tried to start match when user is not host of the room. Cancelling!", LoggingTarget.Runtime, LogLevel.Important);
-                                break;
-                            }
-
-                            // no one is ready, server won't allow starting the map
-                            if (Client.Room?.Users.All(u => u.State != MultiplayerUserState.Ready) ?? false)
-                            {
-                                Logger.Log(@"Tried to start match when no player is ready. Cancelling!", LoggingTarget.Runtime, LogLevel.Important);
-                                botMessageQueue.Enqueue(new Tuple<string, Channel>(@"No player ready, cannot start match.", Channel.Value));
-                                break;
-                            }
-
-                            Client.StartMatch().FireAndForget();
+                            startMatch();
                             break;
                     }
 
@@ -516,6 +503,25 @@ namespace osu.Game.Online.Chat
             }
 
             TextBox.Text = string.Empty;
+        }
+
+        private void startMatch()
+        {
+            if (!Client.IsHost)
+            {
+                Logger.Log(@"Tried to start match when user is not host of the room. Cancelling!", LoggingTarget.Runtime, LogLevel.Important);
+                return;
+            }
+
+            // no one is ready, server won't allow starting the map
+            if (Client.Room?.Users.All(u => u.State != MultiplayerUserState.Ready) ?? false)
+            {
+                Logger.Log(@"Tried to start match when no player is ready. Cancelling!", LoggingTarget.Runtime, LogLevel.Important);
+                botMessageQueue.Enqueue(new Tuple<string, Channel>(@"No player ready, cannot start match.", Channel.Value));
+                return;
+            }
+
+            Client.StartMatch().FireAndForget();
         }
 
         private void abortTimer()

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -342,6 +342,13 @@ namespace osu.Game.Online.Chat
                                 break;
 
                             case @"start":
+                                // we intentionally do this check both in startMatch and here
+                                if (!Client.IsHost)
+                                {
+                                    Logger.Log(@"Tried to start match when user is not host of the room. Cancelling!", LoggingTarget.Runtime, LogLevel.Important);
+                                    return;
+                                }
+
                                 chatTimerHandler?.SetTimer(TimeSpan.FromSeconds(numericParam), Time.Current, messagePrefix: @"Match starts in", onTimerComplete: startMatch);
                                 break;
                         }

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -499,6 +499,14 @@ namespace osu.Game.Online.Chat
                                 break;
                             }
 
+                            // no one is ready, server won't allow starting the map
+                            if (Client.Room?.Users.All(u => u.State != MultiplayerUserState.Ready) ?? false)
+                            {
+                                Logger.Log(@"Tried to start match when no player is ready. Cancelling!", LoggingTarget.Runtime, LogLevel.Important);
+                                botMessageQueue.Enqueue(new Tuple<string, Channel>(@"No player ready, cannot start match.", Channel.Value));
+                                break;
+                            }
+
                             Client.StartMatch().FireAndForget();
                             break;
                     }

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -340,12 +340,16 @@ namespace osu.Game.Online.Chat
                             case @"timer":
                                 chatTimerHandler?.SetTimer(TimeSpan.FromSeconds(numericParam), Time.Current, Channel.Value);
                                 break;
+
+                            case @"start":
+                                break;
                         }
                     }
                     else
                     {
                         switch (parts[1])
                         {
+                            // i don't think this belongs here in the first place... whatever
                             // ReSharper disable once StringLiteralTypo
                             case @"aborttimer":
                                 abortTimer();
@@ -485,6 +489,17 @@ namespace osu.Game.Online.Chat
                                 return;
 
                             Client.AbortMatch().FireAndForget();
+                            break;
+
+                        // start immediately
+                        case @"start":
+                            if (!Client.IsHost)
+                            {
+                                Logger.Log(@"Tried to start match when user is not host of the room. Cancelling!", LoggingTarget.Runtime, LogLevel.Important);
+                                break;
+                            }
+
+                            Client.StartMatch().FireAndForget();
                             break;
                     }
 

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -338,7 +338,7 @@ namespace osu.Game.Online.Chat
                                 break;
 
                             case @"timer":
-                                chatTimerHandler?.SetTimer(TimeSpan.FromSeconds(numericParam), Time.Current, Channel.Value);
+                                chatTimerHandler?.SetTimer(TimeSpan.FromSeconds(numericParam), Time.Current);
                                 break;
 
                             case @"start":


### PR DESCRIPTION
This adds both variants of `!mp start`:
- `!mp start` which immediately tries to start the match
- `!mp start <seconds>` which starts a countdown of `<seconds>` seconds

Note that `!mp start` will fail if either the user is not host or if no player is ready (the server rejects the start request).

This PR also includes some cleanup to `ChatTimerHandler`.