### PR TITLE
Merge pull request #28003 from peppy/fix-multi-spectator-music-pause

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -92,7 +92,7 @@ namespace osu.Game
         public const int SAMPLE_DEBOUNCE_TIME = 20;
 
         /// <summary>
-        /// The maximum volume at which audio tracks should playback. This can be set lower than 1 to create some head-room for sound effects.
+        /// The maximum volume at which audio tracks should play back at. This can be set lower than 1 to create some head-room for sound effects.
         /// </summary>
         private const double global_track_volume_adjust = 0.8;
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -314,10 +314,19 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             playerArea.LoadScore(spectatorGameplayState.Score);
         });
 
-        protected override void FailGameplay(int userId)
+        protected override void FailGameplay(int userId) => Schedule(() =>
         {
             // We probably want to visualise this in the future.
-        }
+
+            var instance = instances.Single(i => i.UserId == userId);
+            syncManager.RemoveManagedClock(instance.SpectatorPlayerClock);
+        });
+
+        protected override void PassGameplay(int userId) => Schedule(() =>
+        {
+            var instance = instances.Single(i => i.UserId == userId);
+            syncManager.RemoveManagedClock(instance.SpectatorPlayerClock);
+        });
 
         protected override void QuitGameplay(int userId) => Schedule(() =>
         {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/SpectatorSyncManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/SpectatorSyncManager.cs
@@ -76,6 +76,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         public void RemoveManagedClock(SpectatorPlayerClock clock)
         {
             playerClocks.Remove(clock);
+            Logger.Log($"Removing managed clock from {nameof(SpectatorSyncManager)} ({playerClocks.Count} remain)");
             clock.IsRunning = false;
         }
 
@@ -130,7 +131,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         }
 
         /// <summary>
-        /// Updates the catchup states of all player clocks clocks.
+        /// Updates the catchup states of all player clocks.
         /// </summary>
         private void updatePlayerCatchup()
         {
@@ -176,7 +177,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// </summary>
         private void updateMasterState()
         {
-            MasterClockState newState = playerClocks.Any(s => !s.IsCatchingUp) ? MasterClockState.Synchronised : MasterClockState.TooFarAhead;
+            // Clocks are removed as players complete the beatmap.
+            // Once there are no clocks we want to make sure the track plays out to the end.
+            MasterClockState newState = playerClocks.Count == 0 || playerClocks.Any(s => !s.IsCatchingUp) ? MasterClockState.Synchronised : MasterClockState.TooFarAhead;
 
             if (masterState == newState)
                 return;

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -135,6 +135,7 @@ namespace osu.Game.Screens.Spectate
 
                 case SpectatedUserState.Passed:
                     markReceivedAllFrames(userId);
+                    PassGameplay(userId);
                     break;
 
                 case SpectatedUserState.Failed:
@@ -232,6 +233,12 @@ namespace osu.Game.Screens.Spectate
         /// <param name="userId">The user to start gameplay for.</param>
         /// <param name="spectatorGameplayState">The gameplay state.</param>
         protected abstract void StartGameplay(int userId, SpectatorGameplayState spectatorGameplayState);
+
+        /// <summary>
+        /// Fired when a user passes gameplay.
+        /// </summary>
+        /// <param name="userId">The user which passed.</param>
+        protected virtual void PassGameplay(int userId) { }
 
         /// <summary>
         /// Quits gameplay for a user.


### PR DESCRIPTION
Fix audio being paused in a spectator session when all players finish playing