### PR TITLE
fix overflow in multi slot move crash

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -420,6 +420,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                     moveFailed($@"couldn't parse {slotTextBox.Text} as integer");
                     return;
                 }
+                catch (OverflowException)
+                {
+                    moveFailed($@"{slotTextBox.Text} is too large");
+                    return;
+                }
 
                 var room = Client.Room;
 


### PR DESCRIPTION
game used to crash if a huge number was typed in slot number (why would you...?)