### PR TITLE
fix spectators reappearing after moving player slots

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -376,13 +376,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                             {
                                 slotTextBox = new OsuNumberBox
                                 {
-                                    Width = 200,
+                                    Width = 160,
                                     PlaceholderText = "slot number",
                                 },
                                 moveButton = new RoundedButton
                                 {
-                                    Width = 80,
-                                    Text = "Move",
+                                    Width = 240,
+                                    Text = $@"Move {user.User?.Username ?? ""}",
                                 }
                             }
                         },

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.Multiplayer;
 using osuTK;
@@ -63,7 +64,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
                 // Add panels for all users new to the room except spectators
                 foreach (var user in client.Room.Users.Except(panels.Select(p => p.User)))
+                {
+                    if (user.State == MultiplayerUserState.Spectating)
+                        continue;
+
+                    Logger.Log($@"Adding panel for {user.User?.Username ?? @"<unknown>"} with state {user.State}");
                     panels.Add(new ParticipantPanel(user));
+                }
 
                 // sort users
                 foreach ((var roomUser, int listPosition) in client.Room.Users.Select((value, i) => (value, i)))

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
@@ -6,7 +6,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Logging;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.Multiplayer;
 using osuTK;
@@ -68,7 +67,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                     if (user.State == MultiplayerUserState.Spectating)
                         continue;
 
-                    Logger.Log($@"Adding panel for {user.User?.Username ?? @"<unknown>"} with state {user.State}");
                     panels.Add(new ParticipantPanel(user));
                 }
 


### PR DESCRIPTION
spectators are meant to be hidden when in lobby.


also adds player's name to the move button to make it less confusing when moving players