### PR TITLE
use tournament-suffixed data directory

### DIFF
--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -23,7 +23,7 @@ namespace osu.Desktop
 #if DEBUG
         private const string base_game_name = @"osu-development";
 #else
-        private const string base_game_name = @"osu-referee";
+        private const string base_game_name = @"osu";
 #endif
 
         private static LegacyTcpIpcProvider? legacyIpc;
@@ -89,7 +89,7 @@ namespace osu.Desktop
                         if (val.Length == 0)
                             break;
 
-                        gameName = $"{base_game_name}-{val}";
+                        gameName = $"{base_game_name}-referee-{val}";
                         break;
 
                     case "--debug-client-id":

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -23,7 +23,7 @@ namespace osu.Desktop
 #if DEBUG
         private const string base_game_name = @"osu-development";
 #else
-        private const string base_game_name = @"osu";
+        private const string base_game_name = @"osu-referee";
 #endif
 
         private static LegacyTcpIpcProvider? legacyIpc;
@@ -83,7 +83,10 @@ namespace osu.Desktop
                 {
                     case "--tournament":
                         tournamentClient = true;
-                        gameName = $"{base_game_name}-tournament";
+                        break;
+
+                    case "--acronym":
+                        gameName = $"{base_game_name}-{val}";
                         break;
 
                     case "--debug-client-id":

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -86,6 +86,9 @@ namespace osu.Desktop
                         break;
 
                     case "--acronym":
+                        if (val.Length == 0)
+                            break;
+
                         gameName = $"{base_game_name}-{val}";
                         break;
 


### PR DESCRIPTION
useful for referee client to still work even after updates from upstream are rolled out and upgrades the main realm database

----

adds a command line option `--acronym=<ACRONYM>` which adds `-referee-ACRONYM` to the game data directory (e.g. running osu! with `--acronym=LGA` makes the client use `osu-referee-LGA` as the game's base storage directory (not to be confused with the data storage directory, which can be changed by the user).

once the game has been launched, the data storage directory can be changed to different locations as usual. the data storage location is tied to the acronym