### PR TITLE
Use saner defaults for multiplayer lobby settings

### DIFF
--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -167,7 +167,7 @@ namespace osu.Game.Online.Chat
                 if (botMessageQueue.Count > 0)
                 {
                     (string text, Channel target) = botMessageQueue.Dequeue();
-                    string message = $@"[TESTOpenBot]: {text}";
+                    string message = $@"[FakeBanchoBot]: {text}";
                     sendMessageAndLog(message, target);
                     Scheduler.AddDelayed(processMessageQueue, 1250);
                     return;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -293,13 +293,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         private readonly Bindable<bool> showOsuCookie = new Bindable<bool>();
 
-        private readonly BindableBool forceSortByTeam = new BindableBool();
+        private readonly BindableBool forceSortByTeam = new BindableBool()
+        {
+            Default = true
+        };
 
         private readonly BindableBool showChatWhileSpectating = new BindableBool(true);
 
         private readonly BindableNumber<int> spectateClientCount = new BindableNumber<int>
         {
-            Default = 16,
+            Default = 4,
             MinValue = 1,
             MaxValue = 16,
             Value = 16


### PR DESCRIPTION
- Default lobby size of 16
- Default slots to be sorted by team membership (if in TeamVS)

Also updates bot's prefix from TESTOpenBot to FakeBanchoBot