### PR TITLE
fix logging every referee message

### DIFF
--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -945,7 +945,9 @@ namespace osu.Game.Online.Chat
                 AllowedMods = item.AllowedMods
             };
 
-            var itemsToRemove = Client.Room?.Playlist.Where(playlistItem => !playlistItem.Expired).ToArray() ?? Array.Empty<MultiplayerPlaylistItem>();
+            var itemsToRemove = Client.Room?.Playlist
+                                      .Where(playlistItem => !playlistItem.Expired)
+                                      .ToArray() ?? Array.Empty<MultiplayerPlaylistItem>();
             Task addPlaylistItemTask = Client.AddPlaylistItem(multiplayerItem);
 
             addPlaylistItemTask.FireAndForget(onSuccess: () =>
@@ -979,7 +981,9 @@ namespace osu.Game.Online.Chat
                     continue;
                 }
 
-                if (multiplayerRefereeTracker.Referees.Any(refereeApiUser => refereeApiUser.Equals(message.Sender)))
+                if (parts[0] == @"!mp" && multiplayerRefereeTracker
+                                          .Referees
+                                          .Any(refereeApiUser => refereeApiUser.Equals(message.Sender)))
                 {
                     // sender is a referee, execute command on their behalf
                     Logger.Log($@"Executing '{message.Content}' on behalf of referee {message.Sender}");


### PR DESCRIPTION
logging was treating every addreffed referee's message as a command. should not have affected functionality, but makes logs harder to read

<img width="1324" height="682" alt="image" src="https://github.com/user-attachments/assets/734e2e74-8d43-491e-a2ec-a7d36fbd1973" />
